### PR TITLE
Use SOURCE_DATE_EPOCH to override build date

### DIFF
--- a/MakeTools/prep.sh
+++ b/MakeTools/prep.sh
@@ -81,7 +81,10 @@ then
 	exit 1
 fi
 
-DATE=${DATE:-"`date +'%m/%d/%y %H:%M'`"}
+DATE_FMT='%m/%d/%y %H:%M'
+[ -z "$SOURCE_DATE_EPOCH" ] ||\
+       DATE=${DATE:-"`date -u -d@$SOURCE_DATE_EPOCH "+$DATE_FMT"`"}
+DATE=${DATE:-"`date "+$DATE_FMT"`"}
 
 if [ "$#" = 1 ]
 then


### PR DESCRIPTION
to make reproducible builds of opa-fm packages easier
e.g. for openSUSE

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This invocation will work with GNU date, not BSD date.

Note: there is similar code in Esm/rpm_runmake
but it is effectively dead code, because the `DATE` variable is not exported